### PR TITLE
Extend injection

### DIFF
--- a/lib/pyszn/injection.py
+++ b/lib/pyszn/injection.py
@@ -314,7 +314,7 @@ def _expand_nodes(filename, nodes_definitions):
     # Parse content
     try:
         parsed_topology = parse_txtmeta(topology)
-    except:
+    except Exception:
         log.error(
             ('Skipping node expansion for attribute injection in filename '
              '{} in the lookup path as SZN format parsing failed.'
@@ -410,7 +410,7 @@ def _expand_ports(filename, ports_definitions):
     # Parse content
     try:
         parsed_topology = parse_txtmeta(topology)
-    except:
+    except Exception:
         log.error(
             ('Skipping port expansion for attribute injection in filename '
              '{} in the lookup path as SZN format parsing failed.'
@@ -476,7 +476,7 @@ def _expand_links(filename, links_definitions):
     # Parse content
     try:
         parsed_topology = parse_txtmeta(topology)
-    except:
+    except Exception:
         log.error(
             ('Skipping link expansion for attribute injection in filename '
              '{} in the lookup path as SZN format parsing failed.'

--- a/lib/pyszn/injection.py
+++ b/lib/pyszn/injection.py
@@ -132,15 +132,15 @@ def parse_attribute_injection(injection_file, search_paths=None):
 
             if filename not in result:
                 result[filename] = {}
-                result[filename]['enviroment'] = {}
+                result[filename]['environment'] = {}
                 result[filename]['nodes'] = OrderedDict()
                 result[filename]['ports'] = OrderedDict()
                 result[filename]['links'] = OrderedDict()
 
-            # Enviroment attributes are parsed from the spec
+            # Environment attributes are parsed from the spec
             try:
-                for attribute, value in spec['enviroment'].items():
-                    result[filename]['envieroment'][attribute] = value
+                for attribute, value in spec['environment'].items():
+                    result[filename]['environment'][attribute] = value
             except KeyError:
                 pass
             # Each specification have several "modifiers" associated to it.
@@ -154,10 +154,10 @@ def parse_attribute_injection(injection_file, search_paths=None):
                         if node not in result[filename]['nodes']:
                             result[filename]['nodes'][node] = {}
 
-                            for attribute, value in modifier[
-                                    'attributes'].items():
-                                result[filename]['nodes'][node][
-                                    attribute] = value
+                        for attribute, value in modifier[
+                                'attributes'].items():
+                            result[filename]['nodes'][node][
+                                attribute] = value
 
                 # Ports
                 if 'ports' in modifier:
@@ -166,10 +166,10 @@ def parse_attribute_injection(injection_file, search_paths=None):
                         if port not in result[filename]['ports']:
                             result[filename]['ports'][port] = {}
 
-                            for attribute, value in modifier[
-                                    'attributes'].items():
-                                result[filename]['port'][port][
-                                    attribute] = value
+                        for attribute, value in modifier[
+                                'attributes'].items():
+                            result[filename]['port'][port][
+                                attribute] = value
 
                 # Links
                 if 'links' in modifier:
@@ -178,10 +178,10 @@ def parse_attribute_injection(injection_file, search_paths=None):
                         if link not in result[filename]['links']:
                             result[filename]['links'][node] = {}
 
-                            for attribute, value in modifier[
-                                    'attributes'].items():
-                                result[filename]['links'][link][
-                                    attribute] = value
+                        for attribute, value in modifier[
+                                'attributes'].items():
+                            result[filename]['links'][link][
+                                attribute] = value
 
     log.debug('Attribute injection interpreted dictionary:')
     log.debug(result)

--- a/lib/pyszn/parser.py
+++ b/lib/pyszn/parser.py
@@ -307,7 +307,7 @@ def find_topology_in_python(filename):
             if node.targets[0].id == 'TOPOLOGY':
                 return node.value.s
 
-    except:
+    except Exception:
         log.error(format_exc())
     return None
 

--- a/lib/pyszn/parser.py
+++ b/lib/pyszn/parser.py
@@ -202,6 +202,18 @@ def parse_txtmeta(txtmeta):
                     ),
                     'attributes': attrs
                 })
+
+                data['nodes'].append({
+                    'nodes': [link.endpoint_a.node, link.endpoint_b.node],
+                    'attributes': OrderedDict()
+                })
+                data['ports'].append({
+                    'ports': [
+                        (link.endpoint_a.node, link.endpoint_a.port),
+                        (link.endpoint_b.node, link.endpoint_b.port)
+                    ],
+                    'attributes': OrderedDict()
+                })
                 continue
 
             # Process port lines
@@ -211,6 +223,10 @@ def parse_txtmeta(txtmeta):
                         (port.node, port.port) for port in parsed.ports
                     ],
                     'attributes': attrs
+                })
+                data['nodes'].append({
+                    'nodes': [port.node for port in parsed.ports],
+                    'attributes': OrderedDict()
                 })
                 continue
 

--- a/lib/pyszn/parser.py
+++ b/lib/pyszn/parser.py
@@ -257,6 +257,30 @@ def parse_txtmeta(txtmeta):
             log.debug(e.exc)
             raise e
 
+    # Remove duplicate data created implicitly
+    temp_nodes = OrderedDict()
+    for node_list in data['nodes']:
+        for node in node_list['nodes']:
+            if node not in temp_nodes.keys():
+                temp_nodes[node] = node_list['attributes']
+            else:
+                temp_nodes[node].update(node_list['attributes'])
+
+    temp_ports = OrderedDict()
+    for port_list in data['ports']:
+        for port in port_list['ports']:
+            if port not in temp_ports.keys():
+                temp_ports[port] = port_list['attributes']
+            else:
+                temp_ports[port].update(port_list['attributes'])
+
+    data['nodes'] = [
+        {'nodes': [k], 'attributes': v} for k, v in temp_nodes.items()
+        ]
+
+    data['ports'] = [
+        {'ports': [k], 'attributes': v} for k, v in temp_ports.items()
+    ]
     return data
 
 

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -103,6 +103,18 @@ INJECTION_FILE = """
     {{
         "files": ["test_topology_match_0.py"],
         "modifiers": [
+             {{
+                "links": ["hs1:1 -- sw1:1", "test_attr=test"],
+                "attributes": {{
+                    "link_attr": "link_value"
+                }}
+           }},
+           {{
+                "ports": ["hs1:1", "test_attr=test"],
+                "attributes": {{
+                    "port_attr": "port_value"
+                }}
+            }},
             {{
                 "nodes": ["sw1"],
                 "attributes": {{
@@ -182,8 +194,11 @@ EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
     (
         '{search_path}/test_topology_match_0.py',
         {'environment': {},
-         'ports': OrderedDict(),
-         'links': OrderedDict(),
+         'ports': OrderedDict([(('hs1', '1'), {'port_attr': 'port_value'})]),
+         'links': OrderedDict([((('hs1', '1'), ('sw1', '1')),
+                                {
+                                    'link_attr': 'link_value'
+                                })]),
          'nodes':
          OrderedDict([
             (
@@ -262,6 +277,14 @@ EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
          'nodes':
          OrderedDict([
             (
+                'hs1', {
+                    'image': 'image_for_all_hosts',
+                }
+            ),  (
+                'hs2', {
+                    'image': 'image_for_all_hosts',
+                }
+            ), (
                 'hs3', {
                     'image': 'image_for_all_hosts',
                 }

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -350,5 +350,5 @@ def test_attribute_injection(tmpdir):
     finally:
         try:
             rmtree(workdir)
-        except:
+        except Exception:
             pass

--- a/test/test_injection.py
+++ b/test/test_injection.py
@@ -181,7 +181,11 @@ INJECTION_FILE = """
 EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
     (
         '{search_path}/test_topology_match_0.py',
-        OrderedDict([
+        {'environment': {},
+         'ports': OrderedDict(),
+         'links': OrderedDict(),
+         'nodes':
+         OrderedDict([
             (
                 'sw1', {
                     'image': 'image_for_sw1_sw3_hs1_hs2',
@@ -208,10 +212,14 @@ EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
                     'hardware': 'hardware_for_sw1_sw3_hs1_hs2',
                 }
             ),
-        ])
+         ])}
     ), (
         '{search_path}/subfolder/test_topology_match_1.py',
-        OrderedDict([
+        {'environment': {},
+         'ports': OrderedDict(),
+         'links': OrderedDict(),
+         'nodes':
+         OrderedDict([
             (
                 'sw1', {
                     'image': 'image_for_sw1_sw3_hs1_hs2',
@@ -228,10 +236,14 @@ EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
                     'hardware': 'hardware_for_sw1_sw3_hs1_hs2',
                 }
             ),
-        ])
+         ])}
     ), (
         '{search_path}/test_topology_match_2.py',
-        OrderedDict([
+        {'environment': {},
+         'ports': OrderedDict(),
+         'links': OrderedDict(),
+         'nodes':
+         OrderedDict([
             (
                 'sw4', {
                     'image': 'image_for_sw4_sw5',
@@ -241,10 +253,14 @@ EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
                     'image': 'image_for_sw4_sw5',
                 }
             ),
-        ])
+         ])}
     ), (
         '{search_path}/subfolder/test_topology_match_3.py',
-        OrderedDict([
+        {'environment': {},
+         'ports': OrderedDict(),
+         'links': OrderedDict(),
+         'nodes':
+         OrderedDict([
             (
                 'hs3', {
                     'image': 'image_for_all_hosts',
@@ -262,7 +278,7 @@ EXPECTED_PARSED_INJECTION_FILE = OrderedDict([
                     'image': 'image_for_sw6_sw7',
                 }
             ),
-        ])
+         ])}
     )]
 )
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -60,7 +60,11 @@ def test_txtmeta_parse():
         'nodes': [
             {
                 'attributes': OrderedDict([('shell', 'vtysh')]),
-                'nodes': ['sw1', 'sw2']
+                'nodes': ['sw1']
+            },
+            {
+                'attributes': OrderedDict([('shell', 'vtysh')]),
+                'nodes': ['sw2']
             },
             {
                 'attributes': OrderedDict([('type', 'host')]),
@@ -70,32 +74,30 @@ def test_txtmeta_parse():
                 'attributes': OrderedDict(),
                 'nodes': ['hs2']
             },
-            {
-                'attributes': OrderedDict(),
-                'nodes': ['sw1', 'hs1']
-            },
-            {
-                'nodes': ['sw1', 'hs1'],
-                'attributes': OrderedDict()
-            },
-            {
-                'nodes': ['sw1', 'hs2'],
-                'attributes': OrderedDict()
-            },
-
-
         ],
         'ports': [
             {
-                'ports': [('sw1', '1'), ('hs1', '1')],
+                'ports': [('sw1', '1')],
                 'attributes': OrderedDict()
             },
             {
-                'ports': [('sw1', 'a'), ('hs1', 'a')],
+                'ports': [('hs1', '1')],
                 'attributes': OrderedDict()
             },
             {
-                'ports': [('sw1', '4'), ('hs2', 'a')],
+                'ports': [('sw1', 'a')],
+                'attributes': OrderedDict()
+            },
+            {
+                'ports': [('hs1', 'a')],
+                'attributes': OrderedDict()
+            },
+            {
+                'ports': [('sw1', '4')],
+                'attributes': OrderedDict()
+            },
+            {
+                'ports': [('hs2', 'a')],
                 'attributes': OrderedDict()
             },
         ],

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -69,9 +69,36 @@ def test_txtmeta_parse():
             {
                 'attributes': OrderedDict(),
                 'nodes': ['hs2']
-            }
+            },
+            {
+                'attributes': OrderedDict(),
+                'nodes': ['sw1', 'hs1']
+            },
+            {
+                'nodes': ['sw1', 'hs1'],
+                'attributes': OrderedDict()
+            },
+            {
+                'nodes': ['sw1', 'hs2'],
+                'attributes': OrderedDict()
+            },
+
+
         ],
-        'ports': [],
+        'ports': [
+            {
+                'ports': [('sw1', '1'), ('hs1', '1')],
+                'attributes': OrderedDict()
+            },
+            {
+                'ports': [('sw1', 'a'), ('hs1', 'a')],
+                'attributes': OrderedDict()
+            },
+            {
+                'ports': [('sw1', '4'), ('hs2', 'a')],
+                'attributes': OrderedDict()
+            },
+        ],
         'links': [
             {
                 'attributes': OrderedDict(),
@@ -87,6 +114,5 @@ def test_txtmeta_parse():
             }
         ]
     }
-
     ddiff = DeepDiff(dictmeta, expected)
     assert not ddiff

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py3, coverage, doc
+envlist = py3, coverage, doc
 
 [testenv]
 passenv = http_proxy https_proxy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, coverage, doc
+envlist = py27, py3, coverage, doc
 
 [testenv]
 passenv = http_proxy https_proxy
@@ -15,7 +15,7 @@ commands =
         {envsitepackagesdir}/pyszn
 
 [testenv:coverage]
-basepython = python3.4
+basepython = python3
 commands =
     py.test \
         --junitxml=tests.xml \
@@ -28,7 +28,7 @@ commands =
         {envsitepackagesdir}/pyszn
 
 [testenv:doc]
-basepython = python3.4
+basepython = python3
 whitelist_externals =
     dot
 commands =


### PR DESCRIPTION
With this injection supports links port and the environment, also, when searching by attributes, it now supports full regex magic. Serach by name still only supports globs since changing to regex will cause a a break in API.

I'll squash after the PR passes review since it's easier to reverse changes on non-squashed tree.