### PR TITLE
Pin the pyparsing depency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyparsing
+pyparsing==2.4.0


### PR DESCRIPTION
For safety lets pin the pyparsing package to avoid future issues that may
be caused by new releases changes.