### PR TITLE
Up to 10x speedup when parsing attribute injection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,14 @@ Documentation
 Changelog
 =========
 
+1.5.0 (2021-11-04)
+------------------
+
+Changes
+~~~~~~~
+
+- Up to a 10x speedup when parsing attribute injection [Max Nedorezov]
+
 1.4.0 (2021-05-21)
 ------------------
 
@@ -75,7 +83,7 @@ License
 
 .. code-block:: text
 
-   Copyright (C) 2016-2019 Hewlett Packard Enterprise Development LP
+   Copyright (C) 2016-2021 Hewlett Packard Enterprise Development LP
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/pyszn/__init__.py
+++ b/lib/pyszn/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2016-2019 Hewlett Packard Enterprise Development LP
+# Copyright (C) 2016-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,4 +21,4 @@ pyszn module entry point.
 
 __author__ = 'Hewlett Packard Enterprise Development LP'
 __email__ = 'hpe-networking@lists.hp.com'
-__version__ = '1.4.0'
+__version__ = '1.5.0'


### PR DESCRIPTION
One reason why parsing attribute injection is slow is because the same topology strings keep getting parsed again and again. This PR fixes this by caching previously parsed topology strings.

I've seen an up to 10x improvement where what took ~42s now takes ~4.8s and what took 100s now takes ~10s.