### PR TITLE
Add multiline text attribute values support

### DIFF
--- a/lib/pyszn/injection.py
+++ b/lib/pyszn/injection.py
@@ -132,7 +132,8 @@ def parse_attribute_injection(
         injection_spec = loads(fd.read())
 
     # Cache the parsed topologies to not parse them again and again
-    # Key is a topology string and return is a dictionary of the parsed topology
+    # Key is a topology string and return is a dictionary of the parsed
+    # topology
     parsed_topologies_cache = {}
 
     result = OrderedDict()
@@ -166,8 +167,10 @@ def parse_attribute_injection(
                     parsed_topologies_cache[topology] = parsed_topology
                 except Exception:
                     log.error(
-                        ('Skipping node expansion for attribute injection in filename '
-                        '{} in the lookup path as SZN format parsing failed.'
+                        (
+                            'Skipping node expansion for attribute injection '
+                            'in filename {} in the lookup path as SZN format '
+                            'parsing failed.'
                         ).format(filename))
                     log.debug(format_exc())
                     break
@@ -179,7 +182,9 @@ def parse_attribute_injection(
 
                 # Nodes
                 if 'nodes' in modifier:
-                    for node in _expand_nodes(parsed_topology, modifier['nodes']):
+                    for node in _expand_nodes(
+                        parsed_topology, modifier['nodes']
+                    ):
                         if node not in result[filename]['nodes']:
                             result[filename]['nodes'][node] = {}
 
@@ -191,7 +196,9 @@ def parse_attribute_injection(
                 # Ports
                 if 'ports' in modifier:
                     for port in _expand_ports(
-                            parsed_topology, _port_str_to_tuple(modifier['ports'])):
+                        parsed_topology,
+                        _port_str_to_tuple(modifier['ports'])
+                    ):
                         if port not in result[filename]['ports']:
                             result[filename]['ports'][port] = {}
 
@@ -203,7 +210,9 @@ def parse_attribute_injection(
                 # Links
                 if 'links' in modifier:
                     for link in _expand_links(
-                            parsed_topology, _link_str_to_tuple(modifier['links'])):
+                        parsed_topology,
+                        _link_str_to_tuple(modifier['links'])
+                    ):
                         if link not in result[filename]['links']:
                             result[filename]['links'][link] = {}
 
@@ -276,9 +285,11 @@ def _load_topo(filename, szn_dir):
         topology = find_topology_in_python(filename, szn_dir=szn_dir)
         if topology is None:
             log.warning(
-                ('Skipping node expansion for attribute injection in filename '
-                '{} in the lookup path as it does not contain a TOPOLOGY or '
-                'TOPOLOGY_ID definition.').format(filename))
+                (
+                    'Skipping node expansion for attribute injection in '
+                    'filename {} in the lookup path as it does not contain '
+                    ' a TOPOLOGY or TOPOLOGY_ID definition.'
+                ).format(filename))
     else:
         # *.szn files just contain the topology string directly
         with open(filename, 'r') as fd:

--- a/lib/pyszn/parser.py
+++ b/lib/pyszn/parser.py
@@ -324,13 +324,20 @@ def find_topology_in_python(filename, szn_dir=None):
                 return node.value.s
             elif node.targets[0].id == 'TOPOLOGY_ID':
                 if not szn_dir:
-                    raise RuntimeError('Found a TOPOLOGY_ID, but no SZN search path was defined')
+                    raise RuntimeError(
+                        'Found a TOPOLOGY_ID, but no SZN search '
+                        'path was defined'
+                    )
                 topology_id = node.value.s
                 for search_path in szn_dir:
-                    for filename in glob(str(Path(search_path)/'{}.szn'.format(topology_id))):
+                    for filename in glob(str(
+                        Path(search_path)/'{}.szn'.format(topology_id)
+                    )):
                         return Path(filename).read_text(encoding='utf-8')
-                raise FileNotFoundError('Topology file with ID {} could not be found'.format(topology_id))
-
+                raise FileNotFoundError(
+                    'Topology file with ID {} '
+                    'could not be found'.format(topology_id)
+                )
 
     except Exception:
         log.error(format_exc())

--- a/lib/pyszn/parser.py
+++ b/lib/pyszn/parser.py
@@ -56,6 +56,7 @@ import logging
 from glob import glob
 from pathlib import Path
 from copy import deepcopy
+from textwrap import dedent
 from traceback import format_exc
 from collections import OrderedDict
 
@@ -99,7 +100,7 @@ def build_parser():
     """
     ParserElement.setDefaultWhitespaceChars(' \t')
     nl = Suppress(LineEnd())
-    inumber = Word(nums).setParseAction(lambda l, s, t: int(t[0]))
+    inumber = Word(nums).setParseAction(lambda toks: int(toks[0]))
     fnumber = (
         Combine(
             Optional('-') + Word(nums) + '.' + Word(nums) +
@@ -111,6 +112,10 @@ def build_parser():
     ).setParseAction(lambda l, s, t: t[0].casefold() == 'true')
     comment = Literal('#') + restOfLine + nl
     text = QuotedString('"')
+
+    multiline_text = QuotedString('```', multiline=True)
+    multiline_text.addParseAction(lambda t: dedent(t[0]))
+
     identifier = Word(alphas, alphanums + '_')
     empty_line = LineStart() + LineEnd()
     item_list = (
@@ -124,7 +129,7 @@ def build_parser():
     attribute = Group(
         identifier('key') + Suppress(Literal('=')) +
         (
-            custom_list | text | fnumber | inumber | boolean |
+            custom_list | multiline_text | text | fnumber | inumber | boolean |
             identifier
         )('value')
         + Optional(nl)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -19,6 +19,7 @@
 Test suite for module pyszn.parser.
 """
 
+from textwrap import dedent
 from collections import OrderedDict
 
 from deepdiff import DeepDiff
@@ -26,7 +27,7 @@ from deepdiff import DeepDiff
 from pyszn.parser import parse_txtmeta
 
 
-def test_parse():
+def test_basic_parse():
     """
     Tests parsing of a complete SZN
     """
@@ -146,9 +147,9 @@ def test_autonode():
     assert not DeepDiff(actual, expected)
 
 
-def test_multiline():
+def test_multiline_list():
     """
-    Test the support for multiline attributes
+    Test the support for multiline list attributes
     """
     topology = """
     # Environment
@@ -170,6 +171,54 @@ def test_multiline():
             [
                 ('virtual', 'none'), ('awesomeness', 'medium'), ('float', 1.0),
                 ('list', [1, 3.14, True])
+            ]
+        ),
+        'nodes': [],
+        'ports': [],
+        'links': []
+    }
+
+    assert not DeepDiff(actual, expected)
+
+
+def test_multiline_text():
+    """
+    Test the support for multiline text attributes
+    """
+    topology = '''
+    # Environment
+    [
+        virtual=none
+        awesomeness=medium
+        float=1.0
+        multiline_text=```
+            Buenos Aires
+            se ve tan susceptible
+            Es el destino de furia, es
+                lo que en sus caras persiste
+        ```
+    ]
+    '''
+    actual = parse_txtmeta(topology)
+
+    expected = {
+        'environment': OrderedDict(
+            [
+                ('virtual', 'none'),
+                ('awesomeness', 'medium'),
+                ('float', 1.0),
+
+                # Multiline string attribute values are parsed using
+                # textwrap.dedent()
+                (
+                    'multiline_text',
+                    dedent("""
+                        Buenos Aires
+                        se ve tan susceptible
+                        Es el destino de furia, es
+                            lo que en sus caras persiste
+                    """)
+                )
             ]
         ),
         'nodes': [],


### PR DESCRIPTION
Add the capability to specify a multiline text as value of an attribute by using ```.

For example:
~~~
[
  message=```
    Con la luz del sol
    Se derriten mis alas
    Solo encuentro en la oscuridad
      Lo que me une
      Con la ciudad de la furia
  ```
] dut1
~~~

The above text will be parsed as:
```python

    'environment': OrderedDict(),
    'links': [],
    'nodes': [
        {
            'attributes': OrderedDict([
                ('message', '\nCon la luz del sol\nSe derriten mis alas\nSolo encuentro en la oscuridad\n  Lo que me une\n  Con la ciudad de la furia\n'),
            ]),
            'nodes': ['dut1'],
        },
    ],
    'ports': [],
}
```