### PR TITLE
Fix attribute injection incorrectly aborting processing rule

### DIFF
--- a/lib/pyszn/__init__.py
+++ b/lib/pyszn/__init__.py
@@ -21,4 +21,4 @@ pyszn module entry point.
 
 __author__ = 'Hewlett Packard Enterprise Development LP'
 __email__ = 'hpe-networking@lists.hp.com'
-__version__ = '1.7.0'
+__version__ = '1.7.1'

--- a/lib/pyszn/injection.py
+++ b/lib/pyszn/injection.py
@@ -173,7 +173,7 @@ def parse_attribute_injection(
                             'parsing failed.'
                         ).format(filename))
                     log.debug(format_exc())
-                    break
+                    continue
 
             # Each specification have several "modifiers" associated to it.
             # Those modifiers hold the nodes whose attributes are to be


### PR DESCRIPTION
Fix an issue where the attribute injection parser aborted processing a injection rule when it finds a non-topology file in the expanded rule files. Now it continues processing the same rule with next file.